### PR TITLE
Week 3, Walkthrough #6: Requesting Number of Comments

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -34,9 +34,11 @@ import java.util.ArrayList;
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
 
+    private final int MAX_COMMENTS_DEFAULT = 5;
+
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        int maxComments = Integer.parseInt(getParameter(request, "max-comments", "10"));
+        int maxComments = getMaxCommentParam(request, response);
         Query query = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
 
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
@@ -77,6 +79,33 @@ public class DataServlet extends HttpServlet {
         response.sendRedirect("/index.html");
 
     }
+
+    /**
+    * Gets the max-comments parameter to determine how many comments to fetch from Datastore. 
+    * @return int, if the user input was valid it returns the parameter, otherwise it returns the MAX_COMMENT_DEFAULT
+    */
+    private int getMaxCommentParam(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        int maxComments;
+
+        try {
+            maxComments = Integer.parseInt(getParameter(request, "max-comments", "5"));
+            
+            //if user input is negative or 0
+            if(maxComments <= 0) {
+                response.getWriter().println("Invalid parameter.");
+                maxComments = MAX_COMMENTS_DEFAULT;
+            }
+
+        } catch(NumberFormatException e) {
+            //if user input is not a number
+            response.getWriter().println("Invalid parameter.");
+            maxComments = MAX_COMMENTS_DEFAULT;
+        }
+
+        return maxComments;
+    
+    }
+
     /**
     * This method converts a list of comments to a JSON string.
     * @return String, the list of comments as a JSON string
@@ -97,12 +126,12 @@ public class DataServlet extends HttpServlet {
    * @return the request parameter, or the default value if the parameter
    *         was not specified by the client
    */
-  private String getParameter(HttpServletRequest request, String name, String defaultValue) {
-    String value = request.getParameter(name);
-    if (value == null) {
-      return defaultValue;
+    private String getParameter(HttpServletRequest request, String name, String defaultValue) {
+        String value = request.getParameter(name);
+        if (value == null) {
+        return defaultValue;
+        }
+        return value;
     }
-    return value;
-  }
 
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -89,7 +89,7 @@ public class DataServlet extends HttpServlet {
         int maxComments;
 
         try {
-            maxComments = Integer.parseInt(getParameter(request, "max-comments").orElse(""+MAX_COMMENTS_DEFAULT));
+            maxComments = Integer.parseInt(getParameter(request, "max-comments").orElse(Integer.toString(MAX_COMMENTS_DEFAULT)));
             
             //if user input is negative or 0
             if(maxComments <= 0) {

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -29,6 +29,7 @@ import com.google.appengine.api.datastore.Query.SortDirection;
 import java.lang.String;
 import com.google.gson.Gson;
 import java.util.ArrayList;
+import java.util.Optional;
 
 /** Servlet that returns some example content. TODO: modify this file to handle comments data */
 @WebServlet("/data")
@@ -68,9 +69,9 @@ public class DataServlet extends HttpServlet {
         long timestamp = System.currentTimeMillis();
 
         Entity commentEntity = new Entity("Comment");
-        commentEntity.setProperty("name", getParameter(request, "name", ""));
-        commentEntity.setProperty("email", getParameter(request, "email", ""));
-        commentEntity.setProperty("message", getParameter(request, "message", ""));
+        commentEntity.setProperty("name", getParameter(request, "name").orElse("Anonymous"));
+        commentEntity.setProperty("email", getParameter(request, "email").orElse("anonymous"));
+        commentEntity.setProperty("message", getParameter(request, "message").orElse(""));
         commentEntity.setProperty("timestamp", timestamp);
 
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
@@ -88,7 +89,7 @@ public class DataServlet extends HttpServlet {
         int maxComments;
 
         try {
-            maxComments = Integer.parseInt(getParameter(request, "max-comments", "5"));
+            maxComments = Integer.parseInt(getParameter(request, "max-comments").orElse(""+MAX_COMMENTS_DEFAULT));
             
             //if user input is negative or 0
             if(maxComments <= 0) {
@@ -123,15 +124,11 @@ public class DataServlet extends HttpServlet {
     }
 
     /**
-   * @return the request parameter, or the default value if the parameter
-   *         was not specified by the client
+   * @return an Optional of the request parameter
    */
-    private String getParameter(HttpServletRequest request, String name, String defaultValue) {
+    private Optional<String> getParameter(HttpServletRequest request, String name) {
         String value = request.getParameter(name);
-        if (value == null) {
-        return defaultValue;
-        }
-        return value;
+        return Optional.ofNullable(value);
     }
 
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -36,12 +36,14 @@ public class DataServlet extends HttpServlet {
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        int maxComments = Integer.parseInt(getParameter(request, "max-comments", "10"));
         Query query = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
 
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         PreparedQuery results = datastore.prepare(query);
 
         ArrayList<Comment> comments = new ArrayList<Comment>();
+        int numComments = 0;
         for (Entity entity : results.asIterable()) {
             String name = (String) entity.getProperty("name");
             String email = (String) entity.getProperty("email");
@@ -50,6 +52,9 @@ public class DataServlet extends HttpServlet {
 
             Comment comment = new Comment(name, email, message, timestamp);
             comments.add(comment);
+            numComments++;
+            
+            if(numComments == maxComments) break;
         }
         
         response.setContentType("application/json;");

--- a/portfolio/src/main/webapp/css/style.css
+++ b/portfolio/src/main/webapp/css/style.css
@@ -113,7 +113,7 @@ html, body {
     float: right;
 }
 
-#max-comments {
+#max-comments-container {
     float: none;
     width: 20%;
 }

--- a/portfolio/src/main/webapp/css/style.css
+++ b/portfolio/src/main/webapp/css/style.css
@@ -112,3 +112,8 @@ html, body {
 .comment-date {
     float: right;
 }
+
+#max-comments {
+    float: none;
+    width: 20%;
+}

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -186,8 +186,8 @@
                         </div>
                     </form>
                 </div>
-                <div id="max-comments" class="input-field col s12">
-                    <select>
+                <div id="max-comments-container" class="input-field col s12">
+                    <select id="max-comments">
                         <option value="5">5</option>
                         <option value="10">10</option>
                         <option value="25">25</option>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -186,7 +186,15 @@
                         </div>
                     </form>
                 </div>
-                <div id="comment-container"></div>    
+                <div id="max-comments" class="input-field col s12">
+                    <select>
+                        <option value="5">5</option>
+                        <option value="10">10</option>
+                        <option value="25">25</option>
+                    </select>
+                    <label>Number of comments:</label>
+                </div> 
+                <div id="comment-container"></div>
             </div>
         </div> 
     </div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -187,7 +187,7 @@
                     </form>
                 </div>
                 <div id="max-comments-container" class="input-field col s12">
-                    <select id="max-comments">
+                    <select id="max-comments" onchange="loadComments()">
                         <option value="5">5</option>
                         <option value="10">10</option>
                         <option value="25">25</option>

--- a/portfolio/src/main/webapp/js/script.js
+++ b/portfolio/src/main/webapp/js/script.js
@@ -24,6 +24,11 @@ document.addEventListener('DOMContentLoaded', function() {
     var instances = M.Sidenav.init(elems);
 });
 
+document.addEventListener('DOMContentLoaded', function() {
+    var elems = document.querySelectorAll('select');
+    var instances = M.FormSelect.init(elems);
+});
+
 //Switches the project description and image to the project that was clicked on. 
 function switchProject(elem) {
     //get the name of the project that was clicked
@@ -54,7 +59,7 @@ function switchProject(elem) {
 
 //Requests comments from DataServlet and adds it to the page.
 function loadComments() {
-    fetch('/data').then(response => response.json()).then((comments) => {
+    fetch('/data?max-comments=1').then(response => response.json()).then((comments) => {
     var commentContainer = document.getElementById('comment-container');
     //create a div element for each of the commments in the comments array
     var commentElems = comments.map(createCommentElem);

--- a/portfolio/src/main/webapp/js/script.js
+++ b/portfolio/src/main/webapp/js/script.js
@@ -61,6 +61,7 @@ function switchProject(elem) {
 function loadComments() {
     fetch('/data?max-comments='+getSelectedMaxComments()).then(response => response.json()).then((comments) => {
     var commentContainer = document.getElementById('comment-container');
+    commentContainer.innerHTML = "";
     //create a div element for each of the commments in the comments array
     var commentElems = comments.map(createCommentElem);
     //append each commentElem to commentContainer

--- a/portfolio/src/main/webapp/js/script.js
+++ b/portfolio/src/main/webapp/js/script.js
@@ -59,7 +59,7 @@ function switchProject(elem) {
 
 //Requests comments from DataServlet and adds it to the page.
 function loadComments() {
-    fetch('/data?max-comments=1').then(response => response.json()).then((comments) => {
+    fetch('/data?max-comments='+getSelectedMaxComments()).then(response => response.json()).then((comments) => {
     var commentContainer = document.getElementById('comment-container');
     //create a div element for each of the commments in the comments array
     var commentElems = comments.map(createCommentElem);
@@ -68,6 +68,12 @@ function loadComments() {
         commentContainer.appendChild(elem);
     });
   });
+}
+
+//Returns the selected option in the "Number of comments" select form.
+function getSelectedMaxComments() {
+    var select = document.getElementById("max-comments");
+    return select.options[select.selectedIndex].value;
 }
 
 // Creates a div element for a comment with a name, email, date, and message


### PR DESCRIPTION
These commits add the ability to request a specific number of comments from the Datastore. In DataServlet.java, the number of comments fetched from Datastore is limited by the max-comments parameter. The parameter is checked for valid user input. In index.html, I created a new select form for the user to select either 5, 10, or 25 comments. In script.js, I have updated the fetch query string to include the max-comments parameter.