### PR TITLE
Add Java functionality to clean user input

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -43,10 +43,6 @@ public class DataServlet extends HttpServlet {
     private final String[] sortTypes =  new String[]{"newest", "oldest", "popular"};
     private InputCleaner cleaner;
 
-    public void init() {
-        cleaner = new InputCleaner();
-    }
-
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
         int maxComments = getMaxCommentParam(request, response);
@@ -113,9 +109,8 @@ public class DataServlet extends HttpServlet {
         }
         
         Entity commentEntity = new Entity("Comment");
-        String name = cleaner.clean(getParameter(request, "name").orElse("Anonymous"));
-        String message = cleaner.clean(getParameter(request, "message").orElse(""));
-
+        String name = InputCleaner.clean(getParameter(request, "name").orElse("Anonymous"));
+        String message = InputCleaner.clean(getParameter(request, "message").orElse(""));
 
         commentEntity.setProperty("name", name);
         commentEntity.setProperty("message", message);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -15,7 +15,9 @@
 package com.google.sps.servlets;
 
 import com.google.sps.data.Comment;
+import com.google.sps.utilities.InputCleaner;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -39,6 +41,11 @@ public class DataServlet extends HttpServlet {
 
     private final int MAX_COMMENTS_DEFAULT = 5;
     private final String[] sortTypes =  new String[]{"newest", "oldest", "popular"};
+    private InputCleaner cleaner;
+
+    public void init() {
+        cleaner = new InputCleaner();
+    }
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -78,7 +85,6 @@ public class DataServlet extends HttpServlet {
                 break;
             }
         }
-        
         response.setContentType("application/json;");
         response.getWriter().println(convertListToJson(comments));
     }
@@ -87,16 +93,29 @@ public class DataServlet extends HttpServlet {
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         long timestamp = System.currentTimeMillis();
 
-        Entity commentEntity = new Entity("Comment");
-        commentEntity.setProperty("name", getParameter(request, "name").orElse("Anonymous"));
-        commentEntity.setProperty("message", getParameter(request, "message").orElse(""));
-        commentEntity.setProperty("timestamp", timestamp);
-        commentEntity.setProperty("numLikes", 0);
+        Entity commentEntity = createCommentEntity(request);
 
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         datastore.put(commentEntity);
     
         response.sendRedirect("/comments.html");
+
+    }
+
+    private Entity createCommentEntity(HttpServletRequest request) {
+        long timestamp = System.currentTimeMillis();
+
+        Entity commentEntity = new Entity("Comment");
+        String name = cleaner.clean(getParameter(request, "name").orElse("Anonymous"));
+        String message = cleaner.clean(getParameter(request, "message").orElse(""));
+
+
+        commentEntity.setProperty("name", name);
+        commentEntity.setProperty("message", message);
+        commentEntity.setProperty("timestamp", timestamp);
+        commentEntity.setProperty("numLikes", 0);
+
+        return commentEntity;
 
     }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -85,6 +85,7 @@ public class DataServlet extends HttpServlet {
                 break;
             }
         }
+        response.setCharacterEncoding("UTF-8");
         response.setContentType("application/json;");
         response.getWriter().println(convertListToJson(comments));
     }
@@ -105,6 +106,12 @@ public class DataServlet extends HttpServlet {
     private Entity createCommentEntity(HttpServletRequest request) {
         long timestamp = System.currentTimeMillis();
 
+        try {
+            request.setCharacterEncoding("UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            System.out.println("encoding failed.");
+        }
+        
         Entity commentEntity = new Entity("Comment");
         String name = cleaner.clean(getParameter(request, "name").orElse("Anonymous"));
         String message = cleaner.clean(getParameter(request, "message").orElse(""));

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
@@ -35,6 +35,8 @@ public class DeleteDataServlet extends HttpServlet {
         Key commentEntityKey = KeyFactory.createKey("Comment", id);
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         datastore.delete(commentEntityKey);
+
+        response.sendRedirect("/comments.html");
     
     }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
@@ -35,8 +35,6 @@ public class DeleteDataServlet extends HttpServlet {
         Key commentEntityKey = KeyFactory.createKey("Comment", id);
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         datastore.delete(commentEntityKey);
-
-        response.sendRedirect("/comments.html");
     
     }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/SongRecServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/SongRecServlet.java
@@ -72,13 +72,20 @@ public class SongRecServlet extends HttpServlet {
             }
 
         }
-        
+
+        response.setCharacterEncoding("UTF-8");
         response.setContentType("application/json;");
         response.getWriter().println(convertListToJson(songRecs));
     }
 
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        
+        try {
+            request.setCharacterEncoding("UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            System.out.println("encoding failed.");
+        }
 
         Entity songRecEntity = new Entity("SongRec");
         songRecEntity.setProperty("name", InputCleaner.clean(getParameter(request, "name").orElse("")));

--- a/portfolio/src/main/java/com/google/sps/servlets/SongRecServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/SongRecServlet.java
@@ -14,8 +14,10 @@
 
 package com.google.sps.servlets;
 
-import java.io.IOException;
 import com.google.sps.data.SongRec;
+import com.google.sps.utilities.InputCleaner;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -37,7 +39,6 @@ import java.util.Optional;
 public class SongRecServlet extends HttpServlet {
 
     private final long NUM_RECS_TO_LOAD = 5;
-
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -80,7 +81,7 @@ public class SongRecServlet extends HttpServlet {
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
 
         Entity songRecEntity = new Entity("SongRec");
-        songRecEntity.setProperty("name", getParameter(request, "name").orElse(""));
+        songRecEntity.setProperty("name", InputCleaner.clean(getParameter(request, "name").orElse("")));
         songRecEntity.setProperty("numLikes", 0);
 
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();

--- a/portfolio/src/main/java/com/google/sps/utilities/InputCleaner.java
+++ b/portfolio/src/main/java/com/google/sps/utilities/InputCleaner.java
@@ -40,26 +40,6 @@ public class InputCleaner {
     */
     public static String clean(String str) {
 
-        String htmlRemoved = removeHTML(str);
-        String emptyLinesRemoved = removeWhitespace(htmlRemoved);
-        return emptyLinesRemoved;
-    }
-
-    /**
-    * Removes empty lines and spaces from input string using regex.
-    * @return String
-    */
-    private static String removeWhitespace(String str) {
-
-        //regex from https://stackoverflow.com/questions/4123385/remove-all-empty-lines#:~:text=You%20can%20remove%20empty%20lines,string%20having%20the%20empty%20lines.
-       return str.replaceAll("(?m)^[ \t]*\r?\n", "");
-    }
-
-    /**
-    * Replaces common HTML characters with their HTML entities to prevent HTML injection.
-    * @return String
-    */
-    private static String removeHTML(String str) {
         char[] characters = str.toCharArray();
         String[] cleanString = new String[str.length()];
 
@@ -74,7 +54,6 @@ public class InputCleaner {
         }
 
         return String.join("", cleanString);
-
     }
 
 }

--- a/portfolio/src/main/java/com/google/sps/utilities/InputCleaner.java
+++ b/portfolio/src/main/java/com/google/sps/utilities/InputCleaner.java
@@ -40,6 +40,26 @@ public class InputCleaner {
     */
     public static String clean(String str) {
 
+        String htmlRemoved = removeHTML(str);
+        String emptyLinesRemoved = removeWhitespace(htmlRemoved);
+        return emptyLinesRemoved;
+    }
+
+    /**
+    * Removes empty lines and spaces from input string using regex.
+    * @return String
+    */
+    private static String removeWhitespace(String str) {
+
+        //regex from https://stackoverflow.com/questions/4123385/remove-all-empty-lines#:~:text=You%20can%20remove%20empty%20lines,string%20having%20the%20empty%20lines.
+       return str.replaceAll("(?m)^[ \t]*\r?\n", "");
+    }
+
+    /**
+    * Replaces common HTML characters with their HTML entities to prevent HTML injection.
+    * @return String
+    */
+    private static String removeHTML(String str) {
         char[] characters = str.toCharArray();
         String[] cleanString = new String[str.length()];
 
@@ -54,6 +74,7 @@ public class InputCleaner {
         }
 
         return String.join("", cleanString);
+
     }
 
 }

--- a/portfolio/src/main/java/com/google/sps/utilities/InputCleaner.java
+++ b/portfolio/src/main/java/com/google/sps/utilities/InputCleaner.java
@@ -22,20 +22,17 @@ public class InputCleaner {
 
     //HashMap that stores an ASCII value as a key and its HTML entity
     private static HashMap<Integer, String> charToEntity;
-
-    public InputCleaner() {
-
-        charToEntity = new HashMap<Integer, String>();
-
+    static
+    { 
+        charToEntity = new HashMap<Integer, String>(); 
         //common HTML character ASCII codes and their HTML entities
         charToEntity.put(38, "&amp;"); // &
         charToEntity.put(60, "&lt;"); // <
         charToEntity.put(62, "&gt;"); // >
-        charToEntity.put(34, "&quot"); // "
+        charToEntity.put(34, "&quot;"); // "
         charToEntity.put(39, "&#x27;"); // '
         charToEntity.put(47, "&#x2F;"); // /
-
-    }
+    } 
 
     /**
     * Replaces common HTML characters with their HTML entities to prevent HTML injection.
@@ -48,10 +45,11 @@ public class InputCleaner {
 
         for(int i = 0; i < characters.length; i++) {
             //if the character is in the HashMap, it is a common HTML character and needs to be replaced
-            if(charToEntity.containsKey(characters[i])) {
-                cleanString[i] = charToEntity.get(characters[i]);
+            char c = characters[i];
+            if(charToEntity.containsKey((int) c)) {
+                cleanString[i] = charToEntity.get((int) c);
             } else {
-                cleanString[i] = Character.toString(characters[i]);
+                cleanString[i] = Character.toString(c);
             }
         }
 

--- a/portfolio/src/main/java/com/google/sps/utilities/InputCleaner.java
+++ b/portfolio/src/main/java/com/google/sps/utilities/InputCleaner.java
@@ -1,0 +1,61 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.utilities;
+
+import java.nio.charset.StandardCharsets;
+import java.lang.String;
+import java.util.HashMap;
+
+public class InputCleaner {
+
+    //HashMap that stores an ASCII value as a key and its HTML entity
+    private static HashMap<Integer, String> charToEntity;
+
+    public InputCleaner() {
+
+        charToEntity = new HashMap<Integer, String>();
+
+        //common HTML character ASCII codes and their HTML entities
+        charToEntity.put(38, "&amp;"); // &
+        charToEntity.put(60, "&lt;"); // <
+        charToEntity.put(62, "&gt;"); // >
+        charToEntity.put(34, "&quot"); // "
+        charToEntity.put(39, "&#x27;"); // '
+        charToEntity.put(47, "&#x2F;"); // /
+
+    }
+
+    /**
+    * Replaces common HTML characters with their HTML entities to prevent HTML injection.
+    * @return String
+    */
+    public static String clean(String str) {
+
+        char[] characters = str.toCharArray();
+        String[] cleanString = new String[str.length()];
+
+        for(int i = 0; i < characters.length; i++) {
+            //if the character is in the HashMap, it is a common HTML character and needs to be replaced
+            if(charToEntity.containsKey(characters[i])) {
+                cleanString[i] = charToEntity.get(characters[i]);
+            } else {
+                cleanString[i] = Character.toString(characters[i]);
+            }
+        }
+
+        return String.join("", cleanString);
+    }
+
+}

--- a/portfolio/src/main/webapp/js/comment.js
+++ b/portfolio/src/main/webapp/js/comment.js
@@ -51,9 +51,9 @@ function createCommentElem(comment) {
     var deleteButton = document.createElement('button');
     var smile = createSmileButton(jsonComment);
 
-    name.innerText = jsonComment.name;
-    date.innerText = convertTime(jsonComment.timestamp);
-    message.innerText = jsonComment.message;
+    name.innerHTML = jsonComment.name;
+    date.innerHTML = convertTime(jsonComment.timestamp);
+    message.innerHTML = jsonComment.message;
     deleteButton.innerHTML = "<i class='material-icons black-icon'>delete</i>";
     
     commentElem.classList.add("comment");
@@ -65,6 +65,7 @@ function createCommentElem(comment) {
 
     deleteButton.addEventListener("click", () => {
         deleteComment(jsonComment);
+        loadComments();
 
         // Remove the task from the DOM.
         commentElem.remove();

--- a/portfolio/src/main/webapp/js/song-rec.js
+++ b/portfolio/src/main/webapp/js/song-rec.js
@@ -72,7 +72,7 @@ function createRecElem(rec) {
     var recName = document.createElement("p");
     var plusOneButton = createPlusOneButton(jsonRec);
 
-    recName.innerText = jsonRec.name;
+    recName.innerHTML = jsonRec.name;
 
     container.classList.add("song-rec");
 


### PR DESCRIPTION
These commits add a new Java utility class, InputCleaner, to clean user input. Common HTML characters such as <, >, /, etc are replaced by their HTML identities so that they don't execute when added to the page (preventing HTML injection). InputCleaner has one static function that is called by the SongRec and Data classes as they receive user input. I also made it so that requests and responses are encoded in UTF-8. 