### PR TITLE
Store users' liked comments

### DIFF
--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -9,14 +9,16 @@ public final class Comment {
     private final String email;
     private final long timestamp;
     private final long numLikes;
+    private final boolean liked;
     private final long id;
 
-    public Comment(String name, String message, String email, long timestamp, long numLikes, long id) {
+    public Comment(String name, String message, String email, long timestamp, long numLikes, boolean liked, long id) {
         this.name = name;
         this.message = message;
         this.email = email;
         this.timestamp = timestamp;
         this.numLikes = numLikes;
+        this.liked = liked;
         this.id = id;
     }
 
@@ -38,6 +40,10 @@ public final class Comment {
 
     public long getNumLikes() {
         return this.numLikes;
+    }
+
+    public boolean isLiked() {
+        return this.liked;
     }
 
     public long getId() {

--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -23,37 +23,37 @@ public final class Comment {
             this.isLiked = false;
         }
 
-        public CommentBuilder name(String name) {
+        public CommentBuilder setName(String name) {
             this.name = name;
             return this;
         }
 
-        public CommentBuilder message(String message) {
+        public CommentBuilder setMessage(String message) {
             this.message = message;
             return this;
         }
 
-        public CommentBuilder email(String email) {
+        public CommentBuilder setEmail(String email) {
             this.email = email;
             return this;
         }
 
-        public CommentBuilder timestamp(long timestamp) {
+        public CommentBuilder setTimestamp(long timestamp) {
             this.timestamp = timestamp;
             return this;
         }
 
-        public CommentBuilder numLikes(long numLikes) {
+        public CommentBuilder setNumLikes(long numLikes) {
             this.numLikes = numLikes;
             return this;
         }
 
-        public CommentBuilder isLiked(boolean isLiked) {
+        public CommentBuilder setIsLiked(boolean isLiked) {
             this.isLiked = isLiked;
             return this;
         }
 
-        public CommentBuilder id(long id) {
+        public CommentBuilder setId(long id) {
             this.id = id;
             return this;
         }

--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -4,22 +4,88 @@ import java.lang.String;
 
 public final class Comment {
 
+    //Builder class
+    public static final class CommentBuilder {
+
+        private String name;
+        private String message;
+        private String email;
+        private long timestamp;
+        private long numLikes;
+        private boolean isLiked;
+        private long id;
+
+        public CommentBuilder() {
+            //set default values
+            this.name = "Anonymous";
+            this.email = "anonymous";
+            this.numLikes = 0;
+            this.isLiked = false;
+        }
+
+        public CommentBuilder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public CommentBuilder message(String message) {
+            this.message = message;
+            return this;
+        }
+
+        public CommentBuilder email(String email) {
+            this.email = email;
+            return this;
+        }
+
+        public CommentBuilder timestamp(long timestamp) {
+            this.timestamp = timestamp;
+            return this;
+        }
+
+        public CommentBuilder numLikes(long numLikes) {
+            this.numLikes = numLikes;
+            return this;
+        }
+
+        public CommentBuilder isLiked(boolean isLiked) {
+            this.isLiked = isLiked;
+            return this;
+        }
+
+        public CommentBuilder id(long id) {
+            this.id = id;
+            return this;
+        }
+
+        public Comment build() {
+            //if the comment is missing any of these fields, we cannot create a new Comment
+            if(this.message == null || this.timestamp == 0 || this.id == 0) {
+                throw new NullPointerException();
+            }
+
+            return new Comment(this);
+
+        }
+
+    }
+
     private final String name;
     private final String message;
     private final String email;
     private final long timestamp;
     private final long numLikes;
-    private final boolean liked;
+    private final boolean isLiked;
     private final long id;
 
-    public Comment(String name, String message, String email, long timestamp, long numLikes, boolean liked, long id) {
-        this.name = name;
-        this.message = message;
-        this.email = email;
-        this.timestamp = timestamp;
-        this.numLikes = numLikes;
-        this.liked = liked;
-        this.id = id;
+    private Comment(CommentBuilder builder) {
+        this.name = builder.name;
+        this.message = builder.message;
+        this.email = builder.email;
+        this.timestamp = builder.timestamp;
+        this.numLikes = builder.numLikes;
+        this.isLiked = builder.isLiked;
+        this.id = builder.id;
     }
 
     public String getName() {
@@ -43,7 +109,7 @@ public final class Comment {
     }
 
     public boolean isLiked() {
-        return this.liked;
+        return this.isLiked;
     }
 
     public long getId() {

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -131,13 +131,13 @@ public class DataServlet extends HttpServlet {
         boolean isLiked = isCommentLikedByUser(datastore, id);
 
         try {
-            comment = new CommentBuilder().name(name)
-                                        .message(message)
-                                        .email(email)
-                                        .timestamp(timestamp)
-                                        .numLikes(numLikes)
-                                        .isLiked(isLiked)
-                                        .id(id).build();
+            comment = new CommentBuilder().setName(name)
+                                        .setMessage(message)
+                                        .setEmail(email)
+                                        .setTimestamp(timestamp)
+                                        .setNumLikes(numLikes)
+                                        .setIsLiked(isLiked)
+                                        .setId(id).build();
         } catch (NullPointerException e) {
             System.out.println("Missing field (message, timestamp, or id) in comment.");
             comment = null;

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
@@ -23,6 +23,11 @@ import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.Filter;
+import com.google.appengine.api.datastore.Query.FilterOperator;
 
 /** Servlet that deletes comments from Datastore. */
 @WebServlet("/delete-data")
@@ -35,7 +40,26 @@ public class DeleteDataServlet extends HttpServlet {
         Key commentEntityKey = KeyFactory.createKey("Comment", id);
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         datastore.delete(commentEntityKey);
+
+        deleteLikes(datastore, id);
     
+    }
+
+    /**
+    * Delete all Like entities that have given commentId.
+    */
+    private void deleteLikes(DatastoreService datastore, long commentId) {
+
+        //get all Like entities that have given commentId using a Filter
+        Filter filter = FilterOperator.EQUAL.of("commentId", commentId);
+        Query query = new Query("Like").setFilter(filter);
+
+        PreparedQuery results = datastore.prepare(query);
+       
+        for(Entity entity : results.asIterable()) {
+            datastore.delete(entity.getKey());
+        }
+
     }
 
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/LikeCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/LikeCommentServlet.java
@@ -74,7 +74,7 @@ public class LikeCommentServlet extends HttpServlet {
 
         String userId = userService.getCurrentUser().getUserId();
 
-        Entity entity = new Entity("UserInfo");
+        Entity entity = new Entity("Like", userId);
 
         entity.setProperty("commentId", commentId);
         entity.setProperty("userId", userId);

--- a/portfolio/src/main/java/com/google/sps/servlets/LikeCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/LikeCommentServlet.java
@@ -74,9 +74,10 @@ public class LikeCommentServlet extends HttpServlet {
 
         String userId = userService.getCurrentUser().getUserId();
 
-        Entity entity = new Entity("UserInfo", userId);
+        Entity entity = new Entity("UserInfo");
 
         entity.setProperty("commentId", commentId);
+        entity.setProperty("userId", userId);
 
         datastore.put(entity);
 

--- a/portfolio/src/main/java/com/google/sps/servlets/LikeCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/LikeCommentServlet.java
@@ -19,6 +19,8 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import com.google.appengine.api.users.UserService;  
+import com.google.appengine.api.users.UserServiceFactory;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Key;
@@ -49,11 +51,35 @@ public class LikeCommentServlet extends HttpServlet {
 
             datastore.put(commentEntity);
 
+            saveLikedComment(datastore, id);
+
         } catch (EntityNotFoundException e)  {
             response.setContentType("text/html");
             response.getWriter().println("Entity not found.");
         }
     
+    }
+
+    /*
+    * Creates a new UserInfo entity that stores the current user's id and the id of the comment that was liked.
+    */
+    private void saveLikedComment(DatastoreService datastore, long commentId) {
+        
+        UserService userService = UserServiceFactory.getUserService();
+
+        // Only save comments for logged-in users 
+        if (!userService.isUserLoggedIn()) {
+            return;
+        }
+
+        String userId = userService.getCurrentUser().getUserId();
+
+        Entity entity = new Entity("UserInfo", userId);
+
+        entity.setProperty("commentId", commentId);
+
+        datastore.put(entity);
+
     }
 
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/UnlikeCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/UnlikeCommentServlet.java
@@ -80,7 +80,7 @@ public class UnlikeCommentServlet extends HttpServlet {
         //create a filter
         //need to find entity that has userId of the current user and commentId of the comment the user unliked
         CompositeFilter filter = CompositeFilterOperator.and(FilterOperator.EQUAL.of("userId", userId), FilterOperator.EQUAL.of("commentId", commentId));
-        Query query = new Query("UserInfo").setFilter(filter);
+        Query query = new Query("Like").setFilter(filter);
 
         PreparedQuery pq = datastore.prepare(query);
        

--- a/portfolio/src/main/webapp/js/comment.js
+++ b/portfolio/src/main/webapp/js/comment.js
@@ -137,7 +137,7 @@ function createSmileButton(comment) {
 
     numLikesLabel.innerText = comment.numLikes;
     //add "press" class to icon if comment is liked
-    button.innerHTML = "<i class='material-icons smile " + (comment.liked ? "press" : "") + "'>emoji_emotions</i>";
+    button.innerHTML = "<i class='material-icons smile " + (comment.isLiked ? "press" : "") + "'>emoji_emotions</i>";
 
     container.classList.add("smile-container");
     button.classList.add("smile-button");

--- a/portfolio/src/main/webapp/js/comment.js
+++ b/portfolio/src/main/webapp/js/comment.js
@@ -136,7 +136,8 @@ function createSmileButton(comment) {
     var numLikesLabel = document.createElement("span");
 
     numLikesLabel.innerText = comment.numLikes;
-    button.innerHTML = "<i class='material-icons smile'>emoji_emotions</i>";
+    //add "press" class to icon if comment is liked
+    button.innerHTML = "<i class='material-icons smile " + (comment.liked ? "press" : "") + "'>emoji_emotions</i>";
 
     container.classList.add("smile-container");
     button.classList.add("smile-button");


### PR DESCRIPTION
These commits store user likes. When a user is logged in and they like a comment, that like will be saved in Datastore and be visible to the user every time they are logged in. I modified the LikeCommentServlet to create a new "Like" entity whenever a logged in user likes a comment. The user id and comment id is saved. When a user unlikes a comment, the entity is deleted. When comments are fetched from the server and a user is logged in, the DataServlet will filter out the comments the user has liked and set the "isLiked" attribute to true so that the comment is liked on the front-end. Other than that, I created a CommentBuilder class inside of the Comment class to better readability as the Comment class had too many parameters. 