### PR TITLE
Add feature to translate comments

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -38,6 +38,11 @@
         <artifactId>javax.mail-api</artifactId>
         <version>1.6.2</version>
     </dependency>
+    <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-translate</artifactId>
+        <version>1.70.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -13,6 +13,7 @@ public final class Comment {
         private long timestamp;
         private long numLikes;
         private boolean isLiked;
+        private String languageCode;
         private long id;
 
         public CommentBuilder() {
@@ -21,6 +22,7 @@ public final class Comment {
             this.email = "anonymous";
             this.numLikes = 0;
             this.isLiked = false;
+            this.languageCode = "en";
         }
 
         public CommentBuilder setName(String name) {
@@ -52,6 +54,11 @@ public final class Comment {
             this.isLiked = isLiked;
             return this;
         }
+        
+        public CommentBuilder setLanguageCode(String languageCode) {
+            this.languageCode = languageCode;
+            return this;
+        }
 
         public CommentBuilder setId(long id) {
             this.id = id;
@@ -76,6 +83,7 @@ public final class Comment {
     private final long timestamp;
     private final long numLikes;
     private final boolean isLiked;
+    private final String languageCode;
     private final long id;
 
     private Comment(CommentBuilder builder) {
@@ -85,6 +93,7 @@ public final class Comment {
         this.timestamp = builder.timestamp;
         this.numLikes = builder.numLikes;
         this.isLiked = builder.isLiked;
+        this.languageCode = builder.languageCode;
         this.id = builder.id;
     }
 
@@ -110,6 +119,10 @@ public final class Comment {
 
     public boolean isLiked() {
         return this.isLiked;
+    }
+
+    public String getLanguageCode() {
+        return this.languageCode;
     }
 
     public long getId() {

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -134,7 +134,7 @@ public class DataServlet extends HttpServlet {
         long numLikes = (long) entity.getProperty("numLikes");
         long id = entity.getKey().getId();
         boolean isLiked = isCommentLikedByUser(datastore, id);
-        String langaugeCode = getCommentLanguage(message);
+        String languageCode = getCommentLanguage(message);
 
         try {
             comment = new CommentBuilder().setName(name)
@@ -143,7 +143,7 @@ public class DataServlet extends HttpServlet {
                                         .setTimestamp(timestamp)
                                         .setNumLikes(numLikes)
                                         .setIsLiked(isLiked)
-                                        .setLanguageCode(langaugeCode)
+                                        .setLanguageCode(languageCode)
                                         .setId(id).build();
         } catch (NullPointerException e) {
             System.out.println("Missing field (message, timestamp, or id) in comment.");

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -34,11 +34,16 @@ import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.appengine.api.datastore.Query.CompositeFilterOperator;
 import com.google.appengine.api.datastore.Query.CompositeFilter;
 import com.google.appengine.api.datastore.Query.FilterOperator;
+import com.google.cloud.translate.Translate;
+import com.google.cloud.translate.TranslateOptions;
+import com.google.cloud.translate.Translation;
+import com.google.cloud.translate.Detection;
 import java.lang.String;
 import com.google.gson.Gson;
 import java.util.ArrayList;
 import java.util.Optional;
 import java.util.Arrays;
+import java.util.Random; 
 
 
 /** Servlet that returns comments from and adds comments to Datastore. */
@@ -129,6 +134,7 @@ public class DataServlet extends HttpServlet {
         long numLikes = (long) entity.getProperty("numLikes");
         long id = entity.getKey().getId();
         boolean isLiked = isCommentLikedByUser(datastore, id);
+        String langaugeCode = getCommentLanguage(message);
 
         try {
             comment = new CommentBuilder().setName(name)
@@ -137,6 +143,7 @@ public class DataServlet extends HttpServlet {
                                         .setTimestamp(timestamp)
                                         .setNumLikes(numLikes)
                                         .setIsLiked(isLiked)
+                                        .setLanguageCode(langaugeCode)
                                         .setId(id).build();
         } catch (NullPointerException e) {
             System.out.println("Missing field (message, timestamp, or id) in comment.");
@@ -144,6 +151,24 @@ public class DataServlet extends HttpServlet {
         }
 
         return comment;
+
+    }
+
+    /**
+    * Determines the language of the message using the Google Cloud Translate API.
+    * @return String, language code
+    */
+    private String getCommentLanguage(String message) {
+        // API
+        // Translate translate = TranslateOptions.getDefaultInstance().getService();
+        // Detection detection = translate.detect(message);
+        // return detection.getLanguage();
+
+        //TESTING 
+        //return a random language code
+        String[] codes = {"en", "fr", "es"};
+        Random rand = new Random();
+        return codes[rand.nextInt(codes.length)];
 
     }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/TranslationServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/TranslationServlet.java
@@ -1,0 +1,33 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import com.google.cloud.translate.Translate;
+import com.google.cloud.translate.TranslateOptions;
+import com.google.cloud.translate.Translation;
+
+@WebServlet("/translate")
+public class TranslationServlet extends HttpServlet {
+
+ @Override
+ public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    
+  }
+}

--- a/portfolio/src/main/java/com/google/sps/servlets/TranslationServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/TranslationServlet.java
@@ -26,8 +26,23 @@ import com.google.cloud.translate.Translation;
 @WebServlet("/translate")
 public class TranslationServlet extends HttpServlet {
 
- @Override
- public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    
-  }
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        String originalMessage = request.getParameter("message");
+        String languageCode = request.getParameter("languageCode");
+
+        // API
+        // Translate translate = TranslateOptions.getDefaultInstance().getService();
+        // Translation translation =
+        //     translate.translate(originalText, Translate.TranslateOption.targetLanguage(languageCode));
+        // String translatedMessage = translation.getTranslatedText();
+
+        // TESTING
+        String translatedMessage = "This is your translated message.";
+
+        response.setContentType("plain/text; charset=UTF-8");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().println(translatedMessage);
+        
+    }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/TranslationServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/TranslationServlet.java
@@ -25,7 +25,7 @@ import com.google.cloud.translate.Translation;
 
 @WebServlet("/translate")
 public class TranslationServlet extends HttpServlet {
-    
+
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         String originalMessage = request.getParameter("message");
@@ -34,11 +34,11 @@ public class TranslationServlet extends HttpServlet {
         // API
         // Translate translate = TranslateOptions.getDefaultInstance().getService();
         // Translation translation =
-        //     translate.translate(originalText, Translate.TranslateOption.targetLanguage(languageCode));
+        //     translate.translate(originalMessage, Translate.TranslateOption.targetLanguage(languageCode));
         // String translatedMessage = translation.getTranslatedText();
 
         // TESTING
-        String translatedMessage = "This is your translated message.";
+        String translatedMessage = "Detta är ett prov.";
 
         response.setContentType("plain/text; charset=UTF-8");
         response.setCharacterEncoding("UTF-8");

--- a/portfolio/src/main/webapp/css/style.css
+++ b/portfolio/src/main/webapp/css/style.css
@@ -286,3 +286,19 @@ iframe {
     text-align: center;
     margin-bottom: 5%;
 }
+
+.translate-comment {
+    border: none;
+    background-color: transparent;
+    padding: 0;
+    color: #2F4EFC;
+    font-size: 15px;
+    font-weight: 200;
+    margin-top: 1%;
+    cursor: pointer;
+}
+
+.translate-comment:focus {
+    background-color: transparent;
+    outline:none;
+}

--- a/portfolio/src/main/webapp/js/comment.js
+++ b/portfolio/src/main/webapp/js/comment.js
@@ -59,7 +59,8 @@ function createButtonWithLink(buttonText, url) {
 
 //Requests comments from DataServlet and adds it to the page.
 function loadComments() {
-    fetch('/data?max-comments='+getSelection("max-comments")+"&sort-type="+getSelection("sort-type")).then(response => response.json()).then((comments) => {
+    fetch("/data?max-comments="+getSelection("max-comments")+"&sort-type="+getSelection("sort-type")).then(response => response.json()).then((comments) => {
+        console.log(comments);
         var commentContainer = document.getElementById('comment-container');
         commentContainer.innerHTML = "";
         //if there are no comments
@@ -93,38 +94,91 @@ function createCommentElem(comment) {
     var email = document.createElement("p");
     var date = document.createElement("p");
     var message = document.createElement("p");
-    var deleteButton = document.createElement('button');
+    var deleteButton = createDeleteButton(jsonComment, commentElem);
     var smile = createSmileButton(jsonComment);
 
     name.innerHTML = jsonComment.name;
     email.innerHTML = jsonComment.email;
     date.innerHTML = convertTime(jsonComment.timestamp);
     message.innerHTML = jsonComment.message;
-    deleteButton.innerHTML = "<i class='material-icons black-icon'>delete</i>";
     
     commentElem.classList.add("comment");
     name.classList.add("comment-name");
     email.classList.add("comment-email");
     date.classList.add("comment-date");
     message.classList.add("comment-message");
-    deleteButton.classList.add("delete-comment")
-
-
-    deleteButton.addEventListener("click", () => {
-        deleteComment(jsonComment);
-        loadComments();
-        // Remove the task from the DOM.
-        commentElem.remove();
-  });
 
     commentElem.appendChild(name);
     commentElem.appendChild(email);
     commentElem.appendChild(date);
     commentElem.appendChild(message);
+
+
+    //if the comment is not in the language of where the user is, create a translate button
+    var userLanguageCode = navigator.language.split('-')[0];
+    if(jsonComment.languageCode !== userLanguageCode) {
+        var translateButton = createTranslateButton(message, jsonComment.message, userLanguageCode);
+        commentElem.appendChild(translateButton);
+        
+    }
+
     commentElem.appendChild(deleteButton);
     commentElem.appendChild(smile);
 
     return commentElem;
+}
+
+//Creates a Translate button for a comment. When the message is not translated, the button reads "Translate" and when it's clicked, it translates the message.
+//If the message is translated, the button reads "Original message" and when it's clicked, the original message is displayed instead.
+//@return button element
+function createTranslateButton(messageElem, originalMessage, languageCode) {
+    var button = document.createElement("button");
+    button.innerText = "Translate";
+    button.classList.add("translate-comment");
+
+    button.addEventListener("click", () => {
+
+        if(button.classList.contains("translated")) {
+
+            messageElem.innerText = originalMessage;
+            button.innerText = "Translate";
+            button.classList.remove("translated");
+
+        } else {
+
+            const params = new URLSearchParams();
+            params.append("message", originalMessage);
+            params.append("languageCode", languageCode);
+            fetch("/translate", {method: "POST", body: params}).then(response => response.text()).then(translation => {
+                messageElem.innerText = translation;
+                button.innerText = "Original message";
+                button.classList.add("translated");
+            });
+        }
+
+    });
+
+    return button;
+}
+
+
+//Creates the delete button for each comment
+//@return button element with an icon
+function createDeleteButton(comment, commentElem) {
+    var button = document.createElement('button');
+    button.innerHTML = "<i class='material-icons black-icon'>delete</i>";
+    button.classList.add("delete-comment");
+
+    button.addEventListener("click", () => {
+        deleteComment(comment);
+        // Remove the task from the DOM.
+        commentElem.remove();
+
+        loadComments();
+     });
+
+     return button;
+
 }
 
 //Creates the smile (like) button for each comment. 
@@ -186,20 +240,20 @@ function convertTime(timestamp) {
 //Tells the server to delete the comment.
 function deleteComment(comment) {
     const params = new URLSearchParams();
-    params.append('id', comment.id);
-    fetch('/delete-data', {method: 'POST', body: params});
+    params.append("id", comment.id);
+    fetch("/delete-data", {method: "POST", body: params});
 }
 
 //Tells the server to like the comment (increment numLikes)
 function likeComment(comment) {
     const params = new URLSearchParams();
-    params.append('id', comment.id);
-    fetch('/like-comment', {method: 'POST', body: params});
+    params.append("id", comment.id);
+    fetch("/like-comment", {method: "POST", body: params});
 }
 
-//Tells the server to unlike the comment (decrenebt numLikes)
+//Tells the server to unlike the comment (decrement numLikes)
 function unlikeComment(comment) {
     const params = new URLSearchParams();
-    params.append('id', comment.id);
-    fetch('/unlike-comment', {method: 'POST', body: params});
+    params.append("id", comment.id);
+    fetch("/unlike-comment", {method: "POST", body: params});
 }


### PR DESCRIPTION
These commits add a feature to translate comments when needed. I use navigator.language to determine the language of where the user currently is and (will use) the Translate API to detect the language of the comment. If the user's language and comment's language are not the same, a translate button is created for the comment. I created a TranslationServlet which will handle translation through the Translate API. Currently, language detection and translation return static responses.