### PR TITLE
Fix fake translate 

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -17,6 +17,7 @@ package com.google.sps.servlets;
 import com.google.sps.data.Comment;
 import com.google.sps.data.Comment.CommentBuilder;
 import com.google.sps.utilities.InputCleaner;
+import com.google.sps.utilities.CommentTranslate;
 import com.google.sps.utilities.GoogleTranslate;
 import com.google.sps.utilities.FakeTranslate;
 import java.io.IOException;
@@ -57,6 +58,12 @@ public class DataServlet extends HttpServlet {
     private final int MAX_COMMENTS_DEFAULT = 5;
     private final String[] sortTypes =  new String[]{"newest", "oldest", "popular"};
     private InputCleaner cleaner;
+    private static CommentTranslate translator;
+
+    public void init() {
+        //change this new GoogleTranslate when deploying
+        translator = new FakeTranslate();
+    }
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -138,7 +145,7 @@ public class DataServlet extends HttpServlet {
         long numLikes = (long) entity.getProperty("numLikes");
         long id = entity.getKey().getId();
         boolean isLiked = isCommentLikedByUser(datastore, id);
-        String languageCode = getCommentLanguage(message);
+        String languageCode = translator.detectLanguage(message);
         boolean isAuthor = isUserAuthorOfComment(datastore, id);
 
         try {
@@ -191,21 +198,6 @@ public class DataServlet extends HttpServlet {
         }
 
         return false;
-
-    }
-
-    /**
-    * Determines the language of the message using the Google Cloud Translate API.
-    * @return String, language code
-    */
-    private String getCommentLanguage(String message) {
-        //DEPLOY
-        // GoogleTranslate gTranslate = new GoogleTranslate();
-        // return gTranslate.detectLanguage(message);
-
-        //DEV
-        FakeTranslate fakeTranslate = new FakeTranslate();
-        return fakeTranslate.detectLanguage(message);
 
     }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -61,7 +61,7 @@ public class DataServlet extends HttpServlet {
     private static CommentTranslate translator;
 
     public void init() {
-        //change this new GoogleTranslate when deploying
+        //change this to GoogleTranslate when deploying
         translator = new FakeTranslate();
     }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/TranslationServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/TranslationServlet.java
@@ -19,27 +19,26 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import com.google.cloud.translate.Translate;
-import com.google.cloud.translate.TranslateOptions;
-import com.google.cloud.translate.Translation;
+import com.google.sps.utilities.CommentTranslate;
 import com.google.sps.utilities.GoogleTranslate;
 import com.google.sps.utilities.FakeTranslate;
 
 @WebServlet("/translate")
 public class TranslationServlet extends HttpServlet {
 
+    private static CommentTranslate translator;
+
+    public void init() {
+        //change this new GoogleTranslate when deploying
+        translator = new FakeTranslate();
+    }
+
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         String originalMessage = request.getParameter("message");
         String languageCode = request.getParameter("languageCode");
 
-        //DEPLOY
-        // GoogleTranslate gTranslate = new GoogleTranslate();
-        // String translatedMessage = gTranslate.translateMessage(originalMessage, languageCode);
-
-        //DEV
-        FakeTranslate fakeTranslate = new FakeTranslate();
-        String translatedMessage = fakeTranslate.translateMessage(originalMessage, languageCode);
+        String translatedMessage = translator.translateMessage(originalMessage, languageCode);
 
         response.setContentType("plain/text; charset=UTF-8");
         response.setCharacterEncoding("UTF-8");

--- a/portfolio/src/main/java/com/google/sps/servlets/TranslationServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/TranslationServlet.java
@@ -29,7 +29,7 @@ public class TranslationServlet extends HttpServlet {
     private static CommentTranslate translator;
 
     public void init() {
-        //change this new GoogleTranslate when deploying
+        //change this to GoogleTranslate when deploying
         translator = new FakeTranslate();
     }
 


### PR DESCRIPTION
These commits edit the fake translate API implementation in DataServlet and TranslationServlet. Changes include creating one static CommentTranslate (interface) variable in each servlet that stores a translator. Now, I only need to change one line (initializing the fake or real translator) when I deploy.